### PR TITLE
use object-descriptors instead of object.getownpropertydescriptors

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ObjectGetOwnPropertyDescriptors = require('object.getownpropertydescriptors');
+const ObjectGetOwnPropertyDescriptors = require('object-descriptors');
 const util = require('util');
 const timers = require('timers');
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
     "test": "node test"
   },
   "dependencies": {
-    "object.getownpropertydescriptors": "^2.0.3"
+    "object-descriptors": "^0.2.0"
   }
 }


### PR DESCRIPTION
Hi, I notice you're using `object.getownpropertydescriptors` dependency and it was pretty heavy. I build myself a smaller (and well typed) version of `Object.getOwnPropertyDescriptors` polyfill and it would reduce tons of KBs of `util-promisify`.

You can compare these polyfills on bundlephobia:

- `object-descriptors`
  https://bundlephobia.com/result?p=object-descriptors@0.2.0
- `object.getownpropertydescriptors`
  https://bundlephobia.com/result?p=object.getownpropertydescriptors@2.0.3